### PR TITLE
Fix stack overflow for large flatBatchExecutes

### DIFF
--- a/SQLitePlugin.coffee.md
+++ b/SQLitePlugin.coffee.md
@@ -543,9 +543,11 @@
       flatlist.push @db.dbid
       flatlist.push batchExecutesLength
 
-      # THANKS for GUIDANCE:
-      # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push#Merging_two_arrays
-      Array.prototype.push.apply(flatlist, flatBatchExecutes)
+      # Copy flatBatchExecutes in chunks to prevent stack overflow
+      # See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#Using_apply_and_built-in_functions
+      maxBlockSize = 100;
+      for start in [0...flatBatchExecutes.length] by maxBlockSize
+        Array.prototype.push.apply(flatlist, flatBatchExecutes.slice(start, start + maxBlockSize))
 
       flatlist.push 'extra'
 

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -465,12 +465,15 @@ Contact for commercial license: sales@litehelpers.net
   };
 
   SQLitePluginTransaction.prototype.run_batch_flatjson = function(batchExecutesLength, flatBatchExecutes, handlerFor) {
-    var flatlist, mycb;
+    var flatlist, l, maxBlockSize, mycb, ref, ref1, start;
     flatlist = [];
     this.db.dbid = this.db.dbidmap[this.db.dbname];
     flatlist.push(this.db.dbid);
     flatlist.push(batchExecutesLength);
-    Array.prototype.push.apply(flatlist, flatBatchExecutes);
+    maxBlockSize = 100;
+    for (start = l = 0, ref = flatBatchExecutes.length, ref1 = maxBlockSize; ref1 > 0 ? l < ref : l > ref; start = l += ref1) {
+      Array.prototype.push.apply(flatlist, flatBatchExecutes.slice(start, start + maxBlockSize));
+    }
     flatlist.push('extra');
     mycb = function(result) {
       var c, changes, code, errormessage, i, insert_id, j, k, r, ri, rl, row, rows, v;


### PR DESCRIPTION
As we have many SQL statements with an arbitrary amount of placeholders, `flatBatchExecutes` can be a very large array. Some browser engines such as the webview in iOS have a rather low limit for the number of function arguments. Exceeding this limit leads to a stack overflow exception.